### PR TITLE
simple s3 transform dag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
 FROM quay.io/astronomer/astro-runtime:8.3.0
+ADD scripts/s3_countries_transform_script.sh /usr/local/airflow/transform_script.sh

--- a/dags/s3_transform.py
+++ b/dags/s3_transform.py
@@ -1,0 +1,32 @@
+from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
+from airflow import DAG
+from airflow.models.connection import Connection
+from time import time_ns
+from datetime import datetime
+import os
+
+conn = Connection(
+    conn_id="aws_demo",
+    conn_type="aws",
+    extra={
+        "config_kwargs": {
+            "signature_version": "unsigned",
+        },
+    },
+)
+
+env_key = f"AIRFLOW_CONN_{conn.conn_id.upper()}"
+conn_uri = conn.get_uri()
+os.environ[env_key] = conn_uri
+
+with DAG(
+    dag_id="s3", schedule="@once", start_date=datetime(2023, 1, 1), is_paused_upon_creation=False, catchup=False
+) as dag:
+    S3FileTransformOperator(
+        task_id="s3transform",
+        source_s3_key="s3://astro-demos-sample-data/countries.csv",
+        source_aws_conn_id=conn.conn_id,
+        transform_script="/usr/local/airflow/transform_script.sh", # select_expression doesn't work with anonymous S3 access, so have to use transform_script instead. this script was injected by the Dockerfile
+        dest_aws_conn_id=conn.conn_id,
+        dest_s3_key=f"s3://astro-demos-sample-data/uploads/{time_ns()}/europian_countries.csv",
+    )

--- a/scripts/s3_countries_transform_script.sh
+++ b/scripts/s3_countries_transform_script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat "$1" | grep 'Europe' > "$2" # filter to only European countries


### PR DESCRIPTION
a simple DAG that reads from a public S3 bucket, runs a transform script, and uploads it to a new S3 bucket. generates a lineage graph like this:
![image](https://github.com/astronomer/astro-example-dags/assets/4218638/58e303eb-ecf2-4796-8ab1-823f3ba64e5f)

dependent on https://github.com/apache/airflow/pull/31659