### PR TITLE
upgrade to runtime 8.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/astronomer/astro-runtime:8.3.0
+FROM quay.io/astronomer/astro-runtime:8.6.0
 ADD scripts/s3_countries_transform_script.sh /usr/local/airflow/transform_script.sh


### PR DESCRIPTION
upgrade to the new runtime version. needed for the s3 example dag to work