### PR TITLE
deploy to persistent Astro deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
       - build_image_and_deploy:
           context:
              - astro-example-dags
-               #          filters:
-               #            branches:
-               #              only:
-               #                - main
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             docker build -t ${image_tag} .
             docker push ${image_tag}
             curl -sSL install.astronomer.io | sudo bash -s
-            astro deploy -i ${image_tag} ${ASTRO_DEPLOYMENT_ID}
+            astro deploy -i ${image_tag} ${ASTRO_DEPLOYMENT_ID} -f
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,11 @@ jobs:
           name: "Build docker image and push to Quay"
           command: |
             docker login -u="${QUAY_USER}" -p="${QUAY_PASSWORD}" quay.io
-            docker build -t quay.io/astronomer/astro-trial-examples .
-            docker push quay.io/astronomer/astro-trial-examples
+            image_tag=quay.io/astronomer/astro-trial-examples:astro-$(date +%Y%m%d%H%M%S)
+            docker build -t ${image_tag} .
+            docker push ${image_tag}
+            curl -sSL install.astronomer.io | sudo bash -s
+            astro deploy -i ${image_tag} ${ASTRO_DEPLOYMENT_ID}
 
 
 
@@ -37,7 +40,7 @@ workflows:
       - build_image_and_deploy:
           context:
              - astro-example-dags
-          filters:
-            branches:
-              only:
-                - main
+               #          filters:
+               #            branches:
+               #              only:
+               #                - main


### PR DESCRIPTION
modified the template from [here](https://docs.astronomer.io/astro/ci-cd-templates/circleci?tab=custom#image-only-templates) to deploy to a persistent deployment in Astro

deploy successful from https://app.circleci.com/pipelines/github/astronomer/astro-example-dags/20/workflows/a64c86d0-911d-48c2-931c-bb9df44ce2dc/jobs/15, before https://github.com/astronomer/astro-example-dags/pull/5/commits/aa2108b3ef727efc5efd9ce7839c29c2f09f6254 to re-instate the behavior to only deploy/push on `main`:
![image](https://github.com/astronomer/astro-example-dags/assets/4218638/64c55802-a1b4-4552-a54f-308067b44e00)
