### PR TITLE
Make DAG paused by default

### DIFF
--- a/dags/s3_transform.py
+++ b/dags/s3_transform.py
@@ -20,7 +20,7 @@ conn_uri = conn.get_uri()
 os.environ[env_key] = conn_uri
 
 with DAG(
-    dag_id="s3", schedule="@once", start_date=datetime(2023, 1, 1), is_paused_upon_creation=False, catchup=False
+    dag_id="s3", schedule="@once", start_date=datetime(2023, 1, 1), catchup=False
 ) as dag:
     S3FileTransformOperator(
         task_id="s3transform",


### PR DESCRIPTION
As the docs team was going through the onboarding workflow, we noticed this detail. This seems like it would be jarring both to:

- Trial users, who suddenly are spending credits without even going to see their DAG run.
- Experienced Airflow users, who tend to manually unpause DAGs that are still being tested.

I think removing this and requiring onboarding users to trigger the DAG themselves, even though it's one more step, would be more user-friendly and consistent with the workflows they expect to complete in Astro.